### PR TITLE
Logging PID data to CSV during test run

### DIFF
--- a/drone_app/PID.py
+++ b/drone_app/PID.py
@@ -21,7 +21,7 @@ class PID:
         self.current_point=0
 
         self.PID_old_time=0
-        self.PID_dt=0
+
 
         self.first=True
 
@@ -41,7 +41,10 @@ class PID:
 
         #calculates dt
         #TODO: I think we shoul pass dt into this directly from the sensor somehow, to not rely on os clock precision
-        self.PID_dt=time.time()-self.PID_old_time
+        time_now = time.time()
+        PID_dt=time_now-self.PID_old_time
+        self.PID_old_time = time_now
+
 
         #calculates error
         self.error=self.set_point-self.current_point
@@ -50,10 +53,10 @@ class PID:
         self.PID_derror=self.error-self.error_old
 
         #calculates integral term
-        self.integral_term=self.integral_term+(self.PID_dt*self.error)
+        self.integral_term=self.integral_term+(PID_dt*self.error)
 
         #calculates derivative term
-        self.derivative_term=self.PID_derror/self.PID_dt
+        self.derivative_term=self.PID_derror/PID_dt
 
         #calculates motor_output using PID equation
         self.motor_output=(self.proportional_gain*self.error)+(self.integral_gain*self.integral_term)+(self.derivative_gain*self.derivative_term)

--- a/tests/test_PID.py
+++ b/tests/test_PID.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import time
 import logging
 import sys
+import csv
 
 from drone_app.PID import PID
 
@@ -19,6 +20,23 @@ logger.setLevel(logging.INFO)
 class TestSensorData(TestCase):
 
 
+
+    #Extension of the TestCase class, called once per test in this class
+    def setUp(self):
+        self.pid_response_handle = open('pid_response.csv', 'w+')
+        self.pid_response_writer = csv.writer(self.pid_response_handle)
+        self.pid_response_writer.writerow(['timestamp','value_at_timestamp'])
+
+
+    def tearDown(self):
+        if self.pid_response_handle:
+            self.pid_response_writer = None
+            self.pid_response_handle.close()
+            self.pid_response_handle = None
+
+
+
+
     def test_change_impulse(self):
         testPID=PID(0.1,0,0)
 
@@ -28,7 +46,7 @@ class TestSensorData(TestCase):
         TARGET_SET_POINT = 1.0
         testPID.change_set_point(TARGET_SET_POINT)
 
-        while testPID.current_point != testPID.set_point :
+        while abs((testPID.current_point - testPID.set_point) / testPID.set_point) > 0.0001:
             pid_adjustment = testPID.calculate()  #TODO: Sometimes this method throws a division by zero, I expect it occurs if the time rounds to the same value (race condition)
             simulated_new_point = testPID.current_point+pid_adjustment
             # NOTE: We can make this test more comprehensive by making the simulated_new_point more comprehensive a simulation
@@ -39,6 +57,7 @@ class TestSensorData(TestCase):
             logger.info('Set Point: {}, Current Point {}, Adjustment {}'.format(testPID.set_point,
                                                                                  testPID.current_point,
                                                                                  pid_adjustment))
+            self.pid_response_writer.writerow([testPID.PID_old_time , testPID.current_point])
 
         #TODO: Goal is to be able to confirm something as having ended up correct
         # TODO: So normally you would want to end up with some combination of asserts


### PR DESCRIPTION
This creates a file called  pid_response.csv if it doesn't exist, or appends to it if it does. 

In the process of getting that to work noticed two issues: 

1. "old time" in pid was not updated 
1. the while loop in the test relied on exactly equal floating point numbers, put a band of accuracy on that